### PR TITLE
Update to Zig 0.14.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,5 +16,5 @@ jobs:
       - uses: actions/checkout@v2
       - uses: goto-bus-stop/setup-zig@v2
         with:
-          version: 0.12.0
+          version: 0.14.0
       - run: zig build test

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-zig-cache/
+.zig-cache/

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,7 @@
 .{
-  .name = "zig-stable-array",
+  .name = .stable_array,
   .version = "0.1.0",
+  .fingerprint = 0xee760748bd6028de,
   .dependencies = .{},
   .paths = .{
     "build.zig",


### PR DESCRIPTION
Aside from the package manager changes, there's also how `page_size` is no longer a comptime-known constant. I considered using `std.heap.pageSize()`, but given the page size is being used in type information, I went with the comptime-known `std.heap.page_size_min`.

Not sure if `page_size_max` would be better?